### PR TITLE
online predictor v2

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -10,6 +10,7 @@ HIGH_PASS = 30
 IMAGES_DIR = "./images"
 RECORDINGS_DIR = "./recordings"
 RECORDING_PARAMS_PATH = "recording_params.json"
+CLASSIFIERS_DIR = "./classifiers"
 
 # BrainFlow, Cyton
 BOARD_ID = BoardIds.CYTON_DAISY_BOARD

--- a/online_classifier.py
+++ b/online_classifier.py
@@ -1,0 +1,87 @@
+
+from recording import *
+from preprocessing import preprocess
+from features import get_features
+import pickle
+import mne
+
+
+def main():
+    params = load_params()
+    classifier_filename = os.path.join(CLASSIFIERS_DIR, "classifier_Haggai_3.pickle")
+    classifier = load_classifier(classifier_filename)
+    raw = run_online_session(params, classifier)
+    save_raw(raw, params)
+
+
+def run_online_session(params, classifier):
+    trial_stims = Marker.all() * params["trials_per_stim"]
+    np.random.shuffle(trial_stims)
+    # start recording
+    board = create_board()
+    board.config_board(HARDWARE_SETTINGS_MSG)
+    board.start_stream()
+    # TODO: Add calibration text
+    sleep(5)
+    # display trials
+    win = visual.Window(units="norm", color=(1, 1, 1))
+    counter = 1
+    total = len(trial_stims)
+    for stim in trial_stims:
+        show_stim_progress(win, counter, total, stim)
+        win.update()
+        sleep(params["get_ready_duration"])
+        win.flip()
+        sleep(params["calibration_duration"])
+        show_stimulus(win, stim)
+        win.update()
+        board.insert_marker(stim)
+        sleep(params["trial_duration"])
+        win.flip()
+        # sleep is necessary to properly access the real-time data
+        sleep(0.5)
+        num_available_data = board.get_board_data_count()
+        # get accumulation of recording, from that extract the current epoch
+        acc_recording_board = board.get_current_board_data(num_available_data)
+        acc_recording = convert_to_mne(acc_recording_board)
+        acc_recording_processed = preprocess(acc_recording)
+        events = mne.find_events(acc_recording_processed)
+        acc_epochs = mne.Epochs(acc_recording_processed, events, stim, tmin=0, tmax=params["trial_duration"], picks="data", baseline=(0, 0))
+        current_epoch = acc_epochs[-1]
+        features = get_features(current_epoch.get_data())
+        prediction = classifier.predict(features)
+        show_classification_result(win, stim, prediction)
+        win.update()
+        sleep(params["display_online_result_duration"])
+        win.flip()
+        counter = counter + 1
+    sleep(params["get_ready_duration"])
+    # stop recording
+    raw = convert_to_mne(board.get_board_data())
+    board.stop_stream()
+    board.release_session()
+    return raw
+
+
+def load_classifier(classifier_filename):
+    pickle_read = open(classifier_filename, "rb")
+    classifier = pickle.load(pickle_read)
+    pickle_read.close()
+    return classifier
+
+
+def show_classification_result(win, stim, prediction):
+    if stim == prediction:
+        msg = 'correct prediction'
+        col = (0, 1, 0)
+    else:
+        msg = 'incorrect prediction'
+        col = (1, 0, 0)
+    visual.TextStim(win=win, text=f'label: {Marker(stim).name}\nprediction: {Marker(prediction).name}\n{msg}',
+                    color=col,
+                    bold=True, pos=(0, 0.8), font='arial').draw()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pipeline.py
+++ b/pipeline.py
@@ -8,6 +8,7 @@ from features import get_features
 from classifier import create_classifier
 import numpy as np
 import scipy.io
+import pickle
 
 
 def main():
@@ -52,6 +53,14 @@ def matlab_data_pipeline():
     features = get_features(epochs.get_data())
     clf, acc = create_classifier(features, labels)
     print(f'k-fold validation accuracy: {np.mean(acc)}')
+
+
+def save_classifier(name, classifier_num, clf):
+    str_classifier = "classifier_{}_{}.pickle".format(name, classifier_num)
+    classifier_filename = os.path.join(CLASSIFIERS_DIR, str_classifier)
+    pickle_write = open(classifier_filename, "wb")
+    pickle.dump(clf, pickle_write)
+    pickle_write.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
here is the PR with the requested changes.

- The dropped epochs bug is fixed, i just needed to insert a small pause before accessing the fresh data.

- there is a new file now called "online_classifier".

- this line needs to be added to the recording_params.json file:
  "display_online_result_duration": 1 

important notes:
- the online predictor seems that it doesn't work correctly because it is always predicting "idle", either for synthetic or EEG data.
- The classifier I used was the one generated using my previous EEG data)
- I tried to look at the real-time data it is using for analysis (plotting channel 1) and it looks pretty normal (values at the correct scale, fluctuating, seems like brain data), so I still don't know what is going on. 

There is a package called "mne-realtime". It might be the correct way to do this. I haven't tried it yet.
